### PR TITLE
Fix stray comma in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,6 @@ setup(
       "Environment :: Console",
       "License :: OSI Approved :: MIT License",
       ],
-    keywords=["optimization", "CMA-ES", "BiteOpt", "differential evolution", "dual annealing", "stochastic", "gradient free", "parallel retry", , "smart retry"],
+    keywords=["optimization", "CMA-ES", "BiteOpt", "differential evolution", "dual annealing", "stochastic", "gradient free", "parallel retry", "smart retry"],
     include_package_data=True,
    )


### PR DESCRIPTION
Remove extra comma resulting in `pip install .` issues.